### PR TITLE
perf: add logging to Tochka unsubscribe operation

### DIFF
--- a/src/main/java/ru/cleardocs/backend/service/TochkaPaymentService.java
+++ b/src/main/java/ru/cleardocs/backend/service/TochkaPaymentService.java
@@ -126,7 +126,14 @@ public class TochkaPaymentService {
             throw new CreatePaymentException("No active subscription to cancel");
         }
 
-        tochkaClient.setSubscriptionStatus(apiKey, operationId);
+        log.info("Tochka unsubscribe: calling setSubscriptionStatus, userId={}, operationId={}", user.getId(), operationId);
+        long startMs = System.currentTimeMillis();
+        try {
+            tochkaClient.setSubscriptionStatus(apiKey, operationId);
+        } finally {
+            long elapsedMs = System.currentTimeMillis() - startMs;
+            log.info("Tochka unsubscribe: setSubscriptionStatus returned in {} ms, userId={}, operationId={}", elapsedMs, user.getId(), operationId);
+        }
         user.setTochkaSubscriptionOperationId(null);
         userRepository.save(user);
 


### PR DESCRIPTION
Add performance logging around the setSubscriptionStatus call during Tochka subscription cancellation. The logs capture the start time and elapsed duration of the external API call, which will help monitor and diagnose potential performance issues in the payment service integration.